### PR TITLE
Add privmsg_message parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,14 @@ And then, configure out_ikachan::
       channel morischan
       message notice: %s [%s] %s
       out_keys tag,time,msg
+      privmsg_message [%s] morischan :D
+      privmsg_out_keys time
       time_key time
       time_format %Y/%m/%d %H:%M:%S
       tag_key tag
     </match>
     
-You will got message like 'notice: alert.servicename [2012/05/10 18:51:59] alert message in attribute "msg"'.
+You will get a notice message like 'notice: alert.servicename [2012/05/10 18:51:59] alert message in attribute "msg"', and a privmsg message like '[2012/05/10 18:51:59] morischan :D'.
 
 ## TODO
 

--- a/fluent-plugin-ikachan.gemspec
+++ b/fluent-plugin-ikachan.gemspec
@@ -14,5 +14,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_development_dependency "fluentd"
+  gem.add_development_dependency "rake"
   gem.add_runtime_dependency "fluentd"
 end

--- a/test/plugin/test_out_ikachan.rb
+++ b/test/plugin/test_out_ikachan.rb
@@ -6,6 +6,28 @@ class IkachanOutputTest < Test::Unit::TestCase
     channel morischan
     message out_ikachan: %s [%s] %s
     out_keys tag,time,msg
+    privmsg_message out_ikachan: %s [%s] %s
+    privmsg_out_keys tag,time,msg
+    time_key time
+    time_format %Y/%m/%d %H:%M:%S
+    tag_key tag
+  ]
+
+  CONFIG_NOTICE_ONLY = %[
+    host localhost
+    channel morischan
+    message out_ikachan: %s [%s] %s
+    out_keys tag,time,msg
+    time_key time
+    time_format %Y/%m/%d %H:%M:%S
+    tag_key tag
+  ]
+
+  CONFIG_PRIVMSG_ONLY = %[
+    host localhost
+    channel morischan
+    privmsg_message out_ikachan: %s [%s] %s
+    privmsg_out_keys tag,time,msg
     time_key time
     time_format %Y/%m/%d %H:%M:%S
     tag_key tag
@@ -18,16 +40,39 @@ class IkachanOutputTest < Test::Unit::TestCase
   def test_configure
     d = create_driver
     assert_equal '#morischan', d.instance.channel
+    d = create_driver(CONFIG_NOTICE_ONLY)
+    assert_equal '#morischan', d.instance.channel
+    d = create_driver(CONFIG_PRIVMSG_ONLY)
+    assert_equal '#morischan', d.instance.channel
   end
 
-  def test_notice
+  def test_notice_and_privmsg
     # To test this code, execute ikachan on your own host
     d = create_driver
     time = Time.now.to_i
     d.run do
-      d.emit({'msg' => "message from fluentd out_ikachan: testing now"}, time)
-      d.emit({'msg' => "message from fluentd out_ikachan: testing second line"}, time)
+      d.emit({'msg' => "both notice and privmsg message from fluentd out_ikachan: testing now"}, time)
+      d.emit({'msg' => "both notice and privmsg message from fluentd out_ikachan: testing second line"}, time)
     end
   end
 
+  def test_notice_only
+    # To test this code, execute ikachan on your own host
+    d = create_driver(CONFIG_NOTICE_ONLY)
+    time = Time.now.to_i
+    d.run do
+      d.emit({'msg' => "notice message from fluentd out_ikachan: testing now"}, time)
+      d.emit({'msg' => "notice message from fluentd out_ikachan: testing second line"}, time)
+    end
+  end
+
+  def test_privmsg_only
+    # To test this code, execute ikachan on your own host
+    d = create_driver(CONFIG_PRIVMSG_ONLY)
+    time = Time.now.to_i
+    d.run do
+      d.emit({'msg' => "privmsg message from fluentd out_ikachan: testing now"}, time)
+      d.emit({'msg' => "privmsg message from fluentd out_ikachan: testing second line"}, time)
+    end
+  end
 end


### PR DESCRIPTION
Hi, @tagomoris -san

I added `privmsg_message` and `privmsg_out_keys` parameter. I want this option parameter so that I can let people know notices by writing their names as privmsg. 

How to use is as belows (I also described in README): 

```
<match alert.**>
  # ikachan host/port(default 4979)
  host localhost
  port 4979
  # channel to notify (this means #morischan)
  channel morischan
  message notice: %s [%s] %s
  out_keys tag,time,msg
  privmsg_message [%s] morischan :D
  privmsg_out_keys time
  time_key time
  time_format %Y/%m/%d %H:%M:%S
  tag_key tag
</match>
```

`privmsg_message` is not a required parameter, but _either_ `message` or `privmsg_message` is required. 

Please let me know if you find something I should fix.
