### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### IkachanOutput
 
-Plugin to send message to IRC, over IRC-HTTP bridge 'Ikachan' by yappo.
+[Fluentd](http://fluentd.org) plugin to send message to IRC, over IRC-HTTP bridge 'Ikachan' by yappo.
 
 About Ikachan:
  * https://metacpan.org/module/ikachan


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
