### PR TITLE
Check HTTP status code with ruby Net::HTTP* classes instead of numbers.

### DIFF
--- a/lib/fluent/plugin/out_ikachan.rb
+++ b/lib/fluent/plugin/out_ikachan.rb
@@ -92,9 +92,9 @@ class Fluent::IkachanOutput < Fluent::Output
 
   def start
     res = http_post_request(@join_uri, {'channel' => @channel})
-    if res.code.to_i == 200
+    if res.kind_of?(Net::HTTPSuccess)
       # ok
-    elsif res.code.to_i == 403 and res.body == "joinned channel: #{@channel}"
+    elsif res.kind_of?(Net::HTTPForbidden) and res.body == "joinned channel: #{@channel}"
       # ok
     else
       raise Fluent::ConfigError, "failed to connect ikachan server #{@host}:#{@port}"

--- a/lib/fluent/plugin/out_ikachan.rb
+++ b/lib/fluent/plugin/out_ikachan.rb
@@ -92,9 +92,9 @@ class Fluent::IkachanOutput < Fluent::Output
 
   def start
     res = http_post_request(@join_uri, {'channel' => @channel})
-    if res.kind_of?(Net::HTTPSuccess)
+    if res.is_a?(Net::HTTPSuccess)
       # ok
-    elsif res.kind_of?(Net::HTTPForbidden) and res.body == "joinned channel: #{@channel}"
+    elsif res.is_a?(Net::HTTPForbidden) and res.body == "joinned channel: #{@channel}"
       # ok
     else
       raise Fluent::ConfigError, "failed to connect ikachan server #{@host}:#{@port}"


### PR DESCRIPTION
Hi.

I would like this plugin to check HTTP status code with ruby classes (e.g. Net::HTTPSuccess) so that it can handle responses like HTTP 204 correctly.
We need this change because we use this plugin with ikasan (ikachan-compatible HipChat gateway: https://github.com/studio3104/ikasan )  and it returns HTTP 204 for some requests.